### PR TITLE
fix: correct NAT Gateway usage type format

### DIFF
--- a/src/pricing/calculators/NatGatewayCalculator.ts
+++ b/src/pricing/calculators/NatGatewayCalculator.ts
@@ -34,13 +34,13 @@ export class NatGatewayCalculator implements ResourceCostCalculator {
         region: normalizeRegion(region),
         filters: [
           { field: 'productFamily', value: 'NAT Gateway' },
-          { field: 'usagetype', value: `${regionPrefix}NatGateway-Hours` },
+          { field: 'usagetype', value: `${regionPrefix}-RegionalNatGateway-Hours` },
         ],
       });
 
       Logger.debug('NAT Gateway hourly rate retrieved', {
         hourlyRate,
-        usageType: `${regionPrefix}NatGateway-Hours`,
+        usageType: `${regionPrefix}-RegionalNatGateway-Hours`,
       });
 
       // Get data processing rate
@@ -49,13 +49,13 @@ export class NatGatewayCalculator implements ResourceCostCalculator {
         region: normalizeRegion(region),
         filters: [
           { field: 'productFamily', value: 'NAT Gateway' },
-          { field: 'usagetype', value: `${regionPrefix}NatGateway-Bytes` },
+          { field: 'usagetype', value: `${regionPrefix}-RegionalNatGateway-Bytes` },
         ],
       });
 
       Logger.debug('NAT Gateway data processing rate retrieved', {
         dataProcessingRate,
-        usageType: `${regionPrefix}NatGateway-Bytes`,
+        usageType: `${regionPrefix}-RegionalNatGateway-Bytes`,
       });
 
       if (hourlyRate === null || dataProcessingRate === null) {


### PR DESCRIPTION
Fixes #26

## Problem
NAT Gateway calculator was using incorrect usage type format for AWS Pricing API queries, resulting in /bin/zsh.00 pricing for all NAT Gateway resources.

## Root Cause
The calculator generated usage types like:
- `EUC1NatGateway-Hours`
- `EUC1NatGateway-Bytes`

But AWS Pricing API expects:
- `EUC1-RegionalNatGateway-Hours`
- `EUC1-RegionalNatGateway-Bytes`

The word "Regional" was missing from the usage type.

## Solution
Updated `NatGatewayCalculator.ts` to use correct usage type format:
```typescript
${regionPrefix}-RegionalNatGateway-Hours
${regionPrefix}-RegionalNatGateway-Bytes
```

## Testing
Tested with eu-central-1 region:
```bash
AWS_PROFILE=testaccount01 npx cdk-cost-analyzer /tmp/empty.json /tmp/with-nat.json --region eu-central-1
```

Result: NAT Gateway now correctly shows **.16/month** (€37.96 hourly + €5.20 data processing)

All tests pass.