### PR TITLE
fix: correct CLI command in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,10 +29,10 @@ jobs:
         run: npm run synth
         working-directory: examples/single-stack
       - name: Run cdk-cost-analyzer on single-stack (text output)
-        run: node ../../dist/cli/index.js cdk.out --output text
+        run: node ../../dist/cli/index.js analyze cdk.out/SingleStackExample.template.json --format text
         working-directory: examples/single-stack
       - name: Run cdk-cost-analyzer on single-stack (json output)
-        run: node ../../dist/cli/index.js cdk.out --output json > cost-report.json
+        run: node ../../dist/cli/index.js analyze cdk.out/SingleStackExample.template.json --format json > cost-report.json
         working-directory: examples/single-stack
       - name: Validate single-stack JSON output
         run: |-
@@ -53,11 +53,11 @@ jobs:
       - name: Synthesize multi-stack
         run: npm run synth
         working-directory: examples/multi-stack
-      - name: Run cdk-cost-analyzer on multi-stack (text output)
-        run: node ../../dist/cli/index.js cdk.out --output text
+      - name: Run cdk-cost-analyzer on multi-stack NetworkingStack (text output)
+        run: node ../../dist/cli/index.js analyze cdk.out/NetworkingStack.template.json --format text
         working-directory: examples/multi-stack
-      - name: Run cdk-cost-analyzer on multi-stack (json output)
-        run: node ../../dist/cli/index.js cdk.out --output json > cost-report.json
+      - name: Run cdk-cost-analyzer on multi-stack NetworkingStack (json output)
+        run: node ../../dist/cli/index.js analyze cdk.out/NetworkingStack.template.json --format json > cost-report.json
         working-directory: examples/multi-stack
       - name: Validate multi-stack JSON output
         run: |-

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -302,12 +302,12 @@ if (project.github) {
       },
       {
         name: 'Run cdk-cost-analyzer on single-stack (text output)',
-        run: 'node ../../dist/cli/index.js cdk.out --output text',
+        run: 'node ../../dist/cli/index.js analyze cdk.out/SingleStackExample.template.json --format text',
         workingDirectory: 'examples/single-stack',
       },
       {
         name: 'Run cdk-cost-analyzer on single-stack (json output)',
-        run: 'node ../../dist/cli/index.js cdk.out --output json > cost-report.json',
+        run: 'node ../../dist/cli/index.js analyze cdk.out/SingleStackExample.template.json --format json > cost-report.json',
         workingDirectory: 'examples/single-stack',
       },
       {
@@ -337,13 +337,13 @@ if (project.github) {
         workingDirectory: 'examples/multi-stack',
       },
       {
-        name: 'Run cdk-cost-analyzer on multi-stack (text output)',
-        run: 'node ../../dist/cli/index.js cdk.out --output text',
+        name: 'Run cdk-cost-analyzer on multi-stack NetworkingStack (text output)',
+        run: 'node ../../dist/cli/index.js analyze cdk.out/NetworkingStack.template.json --format text',
         workingDirectory: 'examples/multi-stack',
       },
       {
-        name: 'Run cdk-cost-analyzer on multi-stack (json output)',
-        run: 'node ../../dist/cli/index.js cdk.out --output json > cost-report.json',
+        name: 'Run cdk-cost-analyzer on multi-stack NetworkingStack (json output)',
+        run: 'node ../../dist/cli/index.js analyze cdk.out/NetworkingStack.template.json --format json > cost-report.json',
         workingDirectory: 'examples/multi-stack',
       },
       {


### PR DESCRIPTION
## Problem

PR #82 introduced an E2E smoke test workflow, but it failed because the CLI command was incorrect.

**Error:**
```
error: unknown command 'cdk.out'
```

The CLI was invoked as:
```bash
node ../../dist/cli/index.js cdk.out --output text
```

But the CLI requires a specific command (analyze/compare/pipeline) and cannot accept a directory path directly.

## Solution

Updated the E2E workflow to use the correct CLI command format:

```bash
# Before (broken):
node ../../dist/cli/index.js cdk.out --output text

# After (fixed):
node ../../dist/cli/index.js analyze cdk.out/SingleStackExample.template.json --format text
```

## Changes

**For single-stack:**
- Uses `analyze cdk.out/SingleStackExample.template.json --format text/json`

**For multi-stack:**
- Uses `analyze cdk.out/NetworkingStack.template.json --format text/json`

## Testing

The E2E workflow will now correctly:
1. Build cdk-cost-analyzer from source
2. Synthesize CDK apps
3. Run CLI with proper command format
4. Validate both text and JSON output
5. Test the full pipeline end-to-end

## Files Changed

- `.projenrc.ts` - Updated CLI commands
- `.github/workflows/e2e.yml` - Regenerated workflow with correct commands

---

Fixes the E2E workflow introduced in #82 (#74)

🤖 Generated with [Claude Code](https://claude.com/claude-code)