### PR TITLE
fix(release): enable npm Trusted Publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,4 +113,5 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -523,4 +523,16 @@ project.addTask('prepare', {
 // The repository does not track CHANGELOG.md - refer to GitHub Releases for version history:
 // https://github.com/buildinginthecloud/cdk-cost-analyzer/releases
 
+// Enable npm Trusted Publishing via OIDC instead of a long-lived NPM_TOKEN.
+// publib-npm requires NPM_TRUSTED_PUBLISHER=true when no token is provided.
+// The GitHub→npm trust is configured at:
+// https://www.npmjs.com/package/cdk-cost-analyzer/access
+const releaseWorkflow = project.tryFindObjectFile('.github/workflows/release.yml');
+if (releaseWorkflow) {
+  releaseWorkflow.addOverride(
+    'jobs.release_npm.steps.3.env.NPM_TRUSTED_PUBLISHER',
+    'true',
+  );
+}
+
 project.synth();

--- a/dist/action/pricing/calculators/CloudWatchCalculator.d.ts
+++ b/dist/action/pricing/calculators/CloudWatchCalculator.d.ts
@@ -1,0 +1,51 @@
+import { ResourceWithId } from '../../diff/types';
+import { ResourceCostCalculator, MonthlyCost, PricingClient } from '../types';
+/**
+ * Calculator for AWS::Logs::LogGroup resources.
+ *
+ * CloudWatch Logs Pricing Model:
+ * - Ingestion: $0.50 per GB (us-east-1)
+ * - Storage: $0.03 per GB-month
+ * - No free tier for ingestion
+ *
+ * @see https://aws.amazon.com/cloudwatch/pricing/
+ */
+export declare class CloudWatchLogsCalculator implements ResourceCostCalculator {
+    private readonly customMonthlyIngestionGB?;
+    private readonly DEFAULT_MONTHLY_INGESTION_GB;
+    private readonly FALLBACK_INGESTION_PRICE_PER_GB;
+    private readonly FALLBACK_STORAGE_PRICE_PER_GB;
+    constructor(customMonthlyIngestionGB?: number | undefined);
+    supports(resourceType: string): boolean;
+    calculateCost(resource: ResourceWithId, region: string, pricingClient: PricingClient): Promise<MonthlyCost>;
+}
+/**
+ * Calculator for AWS::CloudWatch::Alarm resources.
+ *
+ * CloudWatch Alarms Pricing Model:
+ * - Standard resolution alarms (>= 60s period): $0.10 per alarm per month
+ * - High resolution alarms (< 60s period): $0.30 per alarm per month
+ * - Anomaly detection alarms: $0.30 per alarm per month (3 metrics)
+ *
+ * @see https://aws.amazon.com/cloudwatch/pricing/
+ */
+export declare class CloudWatchAlarmCalculator implements ResourceCostCalculator {
+    private readonly FALLBACK_STANDARD_ALARM_PRICE;
+    private readonly FALLBACK_HIGH_RES_ALARM_PRICE;
+    supports(resourceType: string): boolean;
+    calculateCost(resource: ResourceWithId, region: string, pricingClient: PricingClient): Promise<MonthlyCost>;
+}
+/**
+ * Calculator for AWS::CloudWatch::Dashboard resources.
+ *
+ * CloudWatch Dashboards Pricing Model:
+ * - $3.00 per dashboard per month
+ * - First 3 dashboards are free (up to 50 metrics)
+ *
+ * @see https://aws.amazon.com/cloudwatch/pricing/
+ */
+export declare class CloudWatchDashboardCalculator implements ResourceCostCalculator {
+    private readonly FALLBACK_DASHBOARD_PRICE;
+    supports(resourceType: string): boolean;
+    calculateCost(resource: ResourceWithId, region: string, pricingClient: PricingClient): Promise<MonthlyCost>;
+}


### PR DESCRIPTION
## Summary

- Add `NPM_TRUSTED_PUBLISHER=true` env var to the `release_npm` job so `publib-npm` authenticates via GitHub OIDC instead of a long-lived `NPM_TOKEN`.
- Configure the override in `.projenrc.ts` so future `npx projen` runs preserve the setting.

## Context

The `NPM_TOKEN` secret expired, causing the release-to-npm job on `main` to fail with `404 Not Found` (npm returns 404 on auth failures). The token has been deleted and a **Trusted Publisher** was registered on npmjs.com linking `buildinginthecloud/cdk-cost-analyzer` + `release.yml` to the `cdk-cost-analyzer` package.

`publib-npm` requires either `NPM_TOKEN` or `NPM_TRUSTED_PUBLISHER=true` to be set — without either it errors out. This PR wires up the latter so the existing `id-token: write` permission on the job is actually used for OIDC.

## Test plan

- [ ] Merge this PR — release workflow triggers on push to `main`
- [ ] Verify `Publish to npm` step succeeds using OIDC (look for `npm notice publish Signed provenance statement...`)
- [ ] Confirm `cdk-cost-analyzer@0.1.48` (or next version) appears on npmjs.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)