### PR TITLE
fix(release): upgrade npm before trusted publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,4 +114,6 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TRUSTED_PUBLISHER: "true"
-        run: npx -p publib@latest publib-npm
+        run: |-
+          npm install -g npm@latest
+          npx -p publib@latest publib-npm

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -525,6 +525,8 @@ project.addTask('prepare', {
 
 // Enable npm Trusted Publishing via OIDC instead of a long-lived NPM_TOKEN.
 // publib-npm requires NPM_TRUSTED_PUBLISHER=true when no token is provided.
+// npm CLI >= 11.5.1 is required for OIDC; Node 20.18.1 ships with npm 10.x,
+// so we upgrade npm in the publish step before calling publib-npm.
 // The GitHub→npm trust is configured at:
 // https://www.npmjs.com/package/cdk-cost-analyzer/access
 const releaseWorkflow = project.tryFindObjectFile('.github/workflows/release.yml');
@@ -532,6 +534,10 @@ if (releaseWorkflow) {
   releaseWorkflow.addOverride(
     'jobs.release_npm.steps.3.env.NPM_TRUSTED_PUBLISHER',
     'true',
+  );
+  releaseWorkflow.addOverride(
+    'jobs.release_npm.steps.3.run',
+    'npm install -g npm@latest\nnpx -p publib@latest publib-npm',
   );
 }
 


### PR DESCRIPTION
## Summary

Follow-up on #130. The previous PR wired up `NPM_TRUSTED_PUBLISHER=true` so `publib-npm` stopped requiring a token, but the next release still failed — this time with `ENEEDAUTH` coming from `npm publish` itself.

## Root cause

npm Trusted Publishing via OIDC was added in npm CLI 11.5.1. `actions/setup-node@v6` with `node-version: 20.18.1` ships npm 10.x, which does not know how to exchange the GitHub OIDC token for an npm credential. It falls back to interactive auth and errors with:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org
```

## Fix

Install `npm@latest` globally in the `Release` step before invoking `publib-npm`. Configured via a projen `addOverride` so future `npx projen` runs preserve it.

## Test plan

- [ ] Merge → release workflow runs on `main`
- [ ] Verify `npm notice publish Signed provenance statement...` appears
- [ ] Confirm `cdk-cost-analyzer@0.1.48` (or next version) resolves on npmjs.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)